### PR TITLE
Better performance by assuming atomic index writes

### DIFF
--- a/segment_test.go
+++ b/segment_test.go
@@ -76,11 +76,10 @@ func Test_Segment_writeUnsafe(t *testing.T) {
 	timeindexBuf := new(bytes.Buffer)
 
 	s := &Segment{
-		data:                     dataBuf,
-		index:                    indexBuf,
-		timeindex:                timeindexBuf,
-		encodeBuffer:             new(bytes.Buffer),
-		segmentIndexEncodeBuffer: new(bytes.Buffer),
+		data:         dataBuf,
+		index:        indexBuf,
+		timeindex:    timeindexBuf,
+		encodeBuffer: new(bytes.Buffer),
 	}
 
 	m0 := Message{


### PR DESCRIPTION
There was a lot of extra seeking and stat'ing of files because of an assumption that an index could be _partially_ written.

If we don't assume partial writes, we can avoid a lot of extra read overhead because of the size checks versus the current read position.

This results in ~30% increase in performance, which isn't nothing!